### PR TITLE
Improvements to CViTjs embbeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+# Ignore an internal CViTjs installation.
+# Assumes it's been cloned in the js directory
+js/*

--- a/api/blast_ui.api.inc
+++ b/api/blast_ui.api.inc
@@ -875,13 +875,52 @@ function printGFF_parent_children ($gff,$blast_feature_array){
 /**
  * Get text from cvitjs conf file, if possible.
  *
+ * @param $genome_target
+ *   The section of the config to return. Should consist of "data."+[blastdb name].
+ *
  * @return
  *   A string containing the entire contents of the cvitjs configuration file. FALSE otherwise.
  */
-function blast_ui_get_cvit_conf_text() {
-  if ($cvit_conf=blast_ui_get_cvit_conf(variable_get('blast_ui_cvitjs_location', false))) {
-    if ($contents=file_get_contents($cvit_conf)) {
+function blast_ui_get_cvit_conf_text($genome_target = FALSE) {
+
+  // Retrieve the full path and filename of the conf.
+  $cvit_conf = blast_ui_get_cvit_conf(variable_get('blast_ui_cvitjs_location', false));
+  if ($cvit_conf) {
+
+    // Retrieve the contents of the file.
+    $contents = file_get_contents($cvit_conf);
+
+    // If no genome target was provided then return the full file.
+    if ($contents && $genome_target == FALSE) {
       return $contents;
+    }
+
+    // If a genome target was provided, then only return that section.
+    if ($genome_target) {
+      $section = array();
+      $in_section = FALSE;
+
+      // For each line of the configuration file...
+      $section_header = '['.$genome_target.']';
+      $lines = preg_split('/\r\n|\n|\r/', trim($contents));
+      foreach($lines as $l) {
+
+        // Are we in the section for this genome target?
+        if (trim($l) == $section_header) {
+          $in_section = TRUE; }
+
+        // Id so and we haven't fallen out of it through an empty line,
+        // then add it to saved section for returning.
+        if ($in_section) {
+          if (trim($l) == '') { break; }
+          $section[] = trim($l);
+        }
+      }
+
+      // If we found the section, then return it ;-).
+      if (!empty($section)) {
+        return implode("\n", $section);
+      }
     }
   }
 

--- a/includes/blast_ui.admin.inc
+++ b/includes/blast_ui.admin.inc
@@ -152,13 +152,14 @@ KRSLEEGLKTTGEGLDWGVLFGFGPGLTIETVVLRSVAI';
   );
 
   // CVITJS
+  $cvitjs_enabled = variable_get('blast_ui_cvitjs_enabled', FALSE);
   $description = 'The JavaScript program CViTjs enables users to see BLAST hits on an '
                . 'entire genome assembly. See the help tab for information on how to '
                . 'download and set up CViTjs.';
   $form['cvitjs'] = array(
     '#type' => 'fieldset',
     '#collapsible' => true,
-    '#collapsed' => true,
+    '#collapsed' => !$cvitjs_enabled,
     '#title' => 'Enable and configure genome visualization',
     '#description' => $description,
   );
@@ -170,18 +171,20 @@ KRSLEEGLKTTGEGLDWGVLFGFGPGLTIETVVLRSVAI';
     '#markup' => t($description),
   );
 
+
   $form['cvitjs']['cvitjs_enabled'] = array(
     '#type' => 'checkbox',
     '#title' => 'Enable CViTjs',
     '#description' => 'When checked, CViTjs will be enabled.',
-    '#default_value' => variable_get('blast_ui_cvitjs_enabled', FALSE)
+    '#default_value' => $cvitjs_enabled,
   );
 
   $form['cvitjs']['cvitjs_location'] = array(
     '#type' => 'textfield',
     '#title' => 'Path to CViTjs code',
     '#description' => 'Path is relative to the location of this module. Example: js/cvitjs',
-    '#default_value' => variable_get('blast_ui_cvitjs_location', '')
+    '#default_value' => variable_get('blast_ui_cvitjs_location', ''),
+    '#disabled' => !$cvitjs_enabled,
   );
 
   // Get CViTjs confuration text, if possible.

--- a/includes/blast_ui.admin.inc
+++ b/includes/blast_ui.admin.inc
@@ -153,9 +153,11 @@ KRSLEEGLKTTGEGLDWGVLFGFGPGLTIETVVLRSVAI';
 
   // CVITJS
   $cvitjs_enabled = variable_get('blast_ui_cvitjs_enabled', FALSE);
+  $cvitjs_location = variable_get('blast_ui_cvitjs_location', '');
   $description = 'The JavaScript program CViTjs enables users to see BLAST hits on an '
                . 'entire genome assembly. See the help tab for information on how to '
                . 'download and set up CViTjs.';
+
   $form['cvitjs'] = array(
     '#type' => 'fieldset',
     '#collapsible' => true,
@@ -164,9 +166,13 @@ KRSLEEGLKTTGEGLDWGVLFGFGPGLTIETVVLRSVAI';
     '#description' => $description,
   );
 
-  $description = 'CViTjs is only applicable for genome BLAST targets. After it is '
+  $absolute_cvitjs_data_path = DRUPAL_ROOT . '/' . drupal_get_path('module','blast_ui') . '/' . $cvitjs_location . '/data';
+  $description = '<div class ="messages warning">CViTjs is only applicable for genome BLAST targets. After it is '
                . 'enabled here, CViTjs will need to be enabled for each applicable BLAST '
-              . 'target node.';
+              . 'target node.</div>'
+              . '<div class="messages status"><strong>CViTjs Data Location: '.$absolute_cvitjs_data_path.'</strong>'
+              . '<br />The GFF3 and Genome Target-specific CViTjs configuration files should be located'
+              . 'at the above system path. Feel free to organize this directory further.</div>';
   $form['cvitjs']['explanation'] = array(
     '#markup' => t($description),
   );
@@ -183,7 +189,7 @@ KRSLEEGLKTTGEGLDWGVLFGFGPGLTIETVVLRSVAI';
     '#type' => 'textfield',
     '#title' => 'Path to CViTjs code',
     '#description' => 'Path is relative to the location of this module. Example: js/cvitjs',
-    '#default_value' => variable_get('blast_ui_cvitjs_location', ''),
+    '#default_value' => $cvitjs_location,
     '#disabled' => !$cvitjs_enabled,
   );
 

--- a/includes/blast_ui.node.inc
+++ b/includes/blast_ui.node.inc
@@ -245,24 +245,25 @@ function blastdb_form($node, &$form_state) {
       '#title' => t('Show BLAST hits on the genome in the results page.'),
       '#description' => t('Uses CViTjs to display BLAST hits on the entire genome'),
       '#default_value' => (isset($node->cvitjs_enabled)) ? $node->cvitjs_enabled : false,
-//      '#ajax' => array(
-//        'callback' => 'ajax_blast_ui_node_cvitjs_custom_callback',
-//        'wrapper' => 'cvitjs-settings',
-//      )
     );
-    $form['cvitjs']['cvitjs_enabled']['#description'] .= '
-        <p class="blastdb-extra-info">Target Genome Configuration should be under <strong>[data.'.$node->db_name.']</strong> in the main cvit.conf.</p>';
+    $cvitjs_msg_class = 'blastdb-extra-info';
+    $cvitjs_msg = 'Target Genome Configuration should be under <strong>[data.'.$node->db_name.']</strong> in the main cvit.conf.';
 
-
-    if (isset($form_state['values'])) {
-      $cvitjs_enabled = $form_state['values']['cvitjs_enabled'];
-    }
-    else if (isset($node->cvitjs_enabled))  {
-      $cvitjs_enabled = $node->cvitjs_enabled;
+    $conf_section = blast_ui_get_cvit_conf_text('data.'.$node->db_name);
+    if (!$conf_section) {
+      $cvitjs_msg_class .= ' messages warning';
+      $cvitjs_msg .= '<br /><br />There is no section for this genome target defined in the CViTjs
+        configuration file. <strong>No genome visualization will be shown until you define a
+        configuration section, "[data.'.$form_state['values']['db_name'].']", at '
+        .l('Admin > Tripal > Extensions > Tripal BLAST > BLAST UI', 'admin/tripal/extension/tripal_blast')
+        .'</strong>.';
     }
     else {
-      $cvitjs_enabled = false;
+      $cvitjs_msg .= '<br /><br /><strong>Current Configuration:</strong><pre>'.$conf_section.'</pre>';
     }
+
+    $form['cvitjs']['cvitjs_enabled']['#description'] .= '<div class="'.$cvitjs_msg_class.'">'.$cvitjs_msg.'</p>';
+
   }
 
   return $form;
@@ -297,6 +298,19 @@ function blastdb_form_validate($form, $form_state) {
             array('attributes' => array('target' => '_blank')))
         . ' to include a URL prefix before continuing'
       );
+    }
+  }
+
+  // Check that there is a cvitjs section for the current
+  if ($form_state['values']['cvitjs_enabled']) {
+    $conf_section = blast_ui_get_cvit_conf_text('data.'.$form_state['values']['db_name']);
+    if (!$conf_section) {
+      drupal_set_message('There is no section for this genome target defined in the CViTjs
+        configuration file. <strong>No genome visualization will be shown until you define a
+        configuration section, "[data.'.$form_state['values']['db_name'].']", at '
+        .l('Admin > Tripal > Extensions > Tripal BLAST > BLAST UI', 'admin/tripal/extension/tripal_blast')
+        .'</strong>.',
+      'warning');
     }
   }
 }

--- a/includes/blast_ui.node.inc
+++ b/includes/blast_ui.node.inc
@@ -67,7 +67,7 @@ function blastdb_form($node, &$form_state) {
   $form = array();
 
   $form['#validate'] = array('blastdb_form_validate');
-  
+
   $form['#attached']['css'] = array(
     drupal_get_path('module', 'blast_ui') . '/theme/css/form.css',
   );
@@ -106,7 +106,7 @@ function blastdb_form($node, &$form_state) {
   $form['dbxref'] = array(
     '#type' => 'fieldset',
     '#title' => 'Link-outs',
-    '#description' => 'These settings will be used to <em>transform the hit name into a 
+    '#description' => 'These settings will be used to <em>transform the hit name into a
       link to additional information</em>.',
     '#prefix' => '<div id="link-outs">',
     '#suffix' => '</div>',
@@ -122,13 +122,13 @@ function blastdb_form($node, &$form_state) {
   $form['dbxref']['dbxref_linkout_type'] = array(
     '#type' => 'radios',
     '#title' => 'Link-out Type',
-    '#description' => 'This determines how the URL to be linked to is formed. <strong>Make 
-      sure the database chosen supports this type of link</strong> (ie: the database 
+    '#description' => 'This determines how the URL to be linked to is formed. <strong>Make
+      sure the database chosen supports this type of link</strong> (ie: the database
       should point to a GBrowse instance if you choose GBrowse here).',
     '#options' => $options,
     '#default_value' => $linkout_type,
   );
-  
+
   // Add information about each format to the description.
   if ($linkout_type) {
     $form['dbxref']['dbxref_linkout_type']['#description'] .= '
@@ -229,7 +229,7 @@ function blastdb_form($node, &$form_state) {
       '#default_value' => (isset($node->linkout->db_id->db_id)) ? $node->linkout->db_id->db_id : 0
     );
   }
-    
+
   // CViTjs settings, if enabled
   if (variable_get('blast_ui_cvitjs_enabled', false)) {
     $form['cvitjs'] = array(
@@ -239,7 +239,7 @@ function blastdb_form($node, &$form_state) {
       '#prefix' => '<div id="cvitjs-settings">',
       '#suffix' => '</div>',
     );
-    
+
     $form['cvitjs']['cvitjs_enabled'] = array(
       '#type' => 'checkbox',
       '#title' => t('Show BLAST hits on the genome in the results page.'),
@@ -250,6 +250,9 @@ function blastdb_form($node, &$form_state) {
 //        'wrapper' => 'cvitjs-settings',
 //      )
     );
+    $form['cvitjs']['cvitjs_enabled']['#description'] .= '
+        <p class="blastdb-extra-info">Target Genome Configuration should be under <strong>[data.'.$node->db_name.']</strong> in the main cvit.conf.</p>';
+
 
     if (isset($form_state['values'])) {
       $cvitjs_enabled = $form_state['values']['cvitjs_enabled'];
@@ -261,7 +264,7 @@ function blastdb_form($node, &$form_state) {
       $cvitjs_enabled = false;
     }
   }
-  
+
   return $form;
 }
 
@@ -313,7 +316,7 @@ function blastdb_insert($node) {
       $regex = $node->dbxref_id_type;
     }
   }
-  
+
   $db_id = 0;
   if (isset($node->db_id)) {
     $db_id = $node->db_id;
@@ -326,7 +329,7 @@ function blastdb_insert($node) {
   if (!isset($node->cvitjs_enabled)) {
     $node->cvitjs_enabled = 0;
   }
-    
+
   // Actually insert the record.
   db_insert('blastdb')->fields(array(
     'nid'                 => $node->nid,
@@ -365,7 +368,7 @@ function blastdb_update($node) {
       $regex = $node->dbxref_id_type;
     }
   }
-  
+
   $db_id = 0;
   if (isset($node->db_id)) {
     $db_id = $node->db_id;
@@ -374,11 +377,11 @@ function blastdb_update($node) {
   if (!$node->cvitjs_enabled) {
     $node->cvitjs_enabled = 0;
   }
-    
+
   if (!$node->dbxref_linkout_type) {
     $node->dbxref_linkout_type = 'none';
   }
-  
+
   // Update the record.
   db_update('blastdb')->fields(array(
     'name'                => $node->db_name,
@@ -414,9 +417,9 @@ function blastdb_delete($node) {
 function blastdb_load($nodes) {
 
   $sql = "
-    SELECT nid, name, path, dbtype, dbxref_id_regex, dbxref_db_id, 
+    SELECT nid, name, path, dbtype, dbxref_id_regex, dbxref_db_id,
            dbxref_linkout_type, cvitjs_enabled
-    FROM {blastdb} 
+    FROM {blastdb}
     WHERE nid IN (:nids)";
   $result = db_query($sql, array(':nids' => array_keys($nodes)));
 
@@ -441,7 +444,7 @@ function blastdb_load($nodes) {
       tripal_report_error(
         'blast_ui',
         TRIPAL_ERROR,
-        'Unable to find details on the type of link-out choosen (%type). Have you defined hook_blast_linkout_info()? Make sure to clear the cache once you do so.',       
+        'Unable to find details on the type of link-out choosen (%type). Have you defined hook_blast_linkout_info()? Make sure to clear the cache once you do so.',
         array('%type' => $record->dbxref_linkout_type)
       );
     }
@@ -494,7 +497,7 @@ function blastdb_load($nodes) {
       // Support complex link-outs.
       $nodes[$record->nid]->linkout->type = $record->dbxref_linkout_type;
       $nodes[$record->nid]->linkout->url_function = $type['process function'];
-   
+
     }
     // If there is no linkout then provide some defaults.
     else {

--- a/theme/blast_help.tpl.php
+++ b/theme/blast_help.tpl.php
@@ -16,7 +16,7 @@
 <p>This module provides a basic interface to allow your users to utilize your server's NCBI BLAST+.</p>
 
 <p>
-  <a href="#setup">Setup</a> | <a href="#function">Functionality</a> 
+  <a href="#setup">Setup</a> | <a href="#function">Functionality</a>
   | <a href="#protection">Large jobs | <a href="#genomeview">Genome visualization</a>
 </p>
 
@@ -25,32 +25,32 @@
 <h3><b>Setup Instructions</b></h3>
 <ol>
   <li>
-    Install NCBI BLAST+ on your server (Tested with 2.2.26+). There is a 
-    <a href="https://launchpad.net/ubuntu/+source/ncbi-blast+">package available 
-    for Ubuntu</a> to ease installation. Optionally you can set the path to your 
+    Install NCBI BLAST+ on your server (Tested with 2.2.26+). There is a
+    <a href="https://launchpad.net/ubuntu/+source/ncbi-blast+">package available
+    for Ubuntu</a> to ease installation. Optionally you can set the path to your
     BLAST executable <a href="<?php print url('admin/tripal/extension/tripal_blast/blast_ui');?>">
     in the settings</a>.
   </li>
   <li>
-    Optionally, create Tripal External Database References to allow you to link 
-    the records in your BLAST database to further information. To do this simply 
-    go to <a href="<?php print url('admin/tripal/chado/tripal_db/add'); ?>" target="_blank">Tripal> 
-    Chado Modules > Databases > Add DB</a> and make sure to fill in the Database 
-    prefix which will be concatenated with the record IDs in your BLAST database 
-    to determine the link-out to additional information. Note that a regular 
-    expression can be used when creating the BLAST database to indicate what the 
+    Optionally, create Tripal External Database References to allow you to link
+    the records in your BLAST database to further information. To do this simply
+    go to <a href="<?php print url('admin/tripal/chado/tripal_db/add'); ?>" target="_blank">Tripal>
+    Chado Modules > Databases > Add DB</a> and make sure to fill in the Database
+    prefix which will be concatenated with the record IDs in your BLAST database
+    to determine the link-out to additional information. Note that a regular
+    expression can be used when creating the BLAST database to indicate what the
     ID is.
   </li>
   <li>
-    <a href="<?php print url('node/add/blastdb');?>">Create "BLAST Database" 
-    nodes</a> for each dataset you want to make available for your users to BLAST 
-    against. BLAST databases should first be created using the command-line 
-    <code>makeblastdb</code> program with the <code>-parse_seqids</code> flag.  
+    <a href="<?php print url('node/add/blastdb');?>">Create "BLAST Database"
+    nodes</a> for each dataset you want to make available for your users to BLAST
+    against. BLAST databases should first be created using the command-line
+    <code>makeblastdb</code> program with the <code>-parse_seqids</code> flag.
   </li>
   <li>
-    It's recommended that you also install the <a href="http://drupal.org/project/tripal_daemon">Tripal Job Daemon</a> 
-    to manage BLAST jobs and ensure they are run soon after being submitted by the 
-    user. Without this additional module, administrators will have to execute the 
+    It's recommended that you also install the <a href="http://drupal.org/project/tripal_daemon">Tripal Job Daemon</a>
+    to manage BLAST jobs and ensure they are run soon after being submitted by the
+    user. Without this additional module, administrators will have to execute the
     tripal jobs either manually or through use of cron jobs.
   </li>
 </ol>
@@ -59,33 +59,33 @@
 &mdash;
 <h3><b>Highlighted Functionality</b></h3>
 <ul>
-  <li>Supports <a href="<?php print url('blast/nucleotide/nucleotide');?>">blastn</a>, 
-    <a href="<?php print url('blast/nucleotide/protein');?>">blastx</a>, 
-    <a href="<?php print url('blast/protein/protein');?>">blastp</a> and 
+  <li>Supports <a href="<?php print url('blast/nucleotide/nucleotide');?>">blastn</a>,
+    <a href="<?php print url('blast/nucleotide/protein');?>">blastx</a>,
+    <a href="<?php print url('blast/protein/protein');?>">blastp</a> and
     <a href="<?php print url('blast/protein/nucleotide');?>">tblastx</a> with separate forms depending upon the database/query type.
   </li>
   <li>
-    Simple interface allowing users to paste or upload a query sequence and then 
-    select from available databases. Additionally, a FASTA file can be uploaded 
+    Simple interface allowing users to paste or upload a query sequence and then
+    select from available databases. Additionally, a FASTA file can be uploaded
     for use as a database to BLAST against (this functionality can be disabled).
   </li>
   <li>
-    Tabular Results listing with alignment information and multiple download 
+    Tabular Results listing with alignment information and multiple download
     formats (HTML, TSV, XML) available.
   </li>
   <li>
-    Completely integrated with <a href="<?php print url('admin/tripal/tripal_jobs');?>">Tripal Jobs</a> 
-    providing administrators with a way to track BLAST jobs and ensuring long 
+    Completely integrated with <a href="<?php print url('admin/tripal/tripal_jobs');?>">Tripal Jobs</a>
+    providing administrators with a way to track BLAST jobs and ensuring long
     running BLASTs will not cause page time-outs
   </li>
   <li>
-    BLAST databases are made available to the module by 
-    <a href="<?php print url('node/add/blastdb');?>">creating Drupal Pages</a> 
-    describing them. This allows administrators to 
+    BLAST databases are made available to the module by
+    <a href="<?php print url('node/add/blastdb');?>">creating Drupal Pages</a>
+    describing them. This allows administrators to
     <a href="<?php print url('admin/structure/types/manage/blastdb/fields');?>">use the Drupal Field API to add any information they want to these pages</a>.
   </li>
   <li>
-    BLAST database records can be linked to an external source with more 
+    BLAST database records can be linked to an external source with more
     information (ie: NCBI) per BLAST database.
   </li>
 </ul>
@@ -93,17 +93,17 @@
 <a name="protection"</a></a>
 &mdash;
 <h3><b>Protection Against Large Jobs</b></h3>
-Depending on the size and nature of your target databases, you may wish to constrain use 
+Depending on the size and nature of your target databases, you may wish to constrain use
 of this module.
 <ol>
   <li>Limit the number of results displayed via admin page. The recommended number is 500.</li>
   <li>
-    Limit the maximum upload file size in php settings. This is less useful because some 
+    Limit the maximum upload file size in php settings. This is less useful because some
     very large queries may be manageable, and others not.
   </li>
   <li>
-    Repeat-mask your targets, or provide repeat-masked versions. Note that some 
-    researchers may be looking for repeats, so this may limit the usefulness of the BLAST 
+    Repeat-mask your targets, or provide repeat-masked versions. Note that some
+    researchers may be looking for repeats, so this may limit the usefulness of the BLAST
     service.
   </li>
 </ol>
@@ -111,19 +111,21 @@ of this module.
 <a name="genomeview"></a>
 &mdash;
 <h3><b>Whole Genome Visualization</b></h3>
-This module can be configured to use 
-<a href="https://github.com/LegumeFederation/cvitjs">CViTjs</a> to display BLAST hits on 
-a genome image. The process is as follows:
+This module can be configured to use
+<a href="https://github.com/LegumeFederation/cvitjs">CViTjs</a> to display BLAST hits on
+a genome image.
+
+<h4>CViTjs Setup</h4>
 <ol>
   <li>
     <a href="https://github.com/LegumeFederation/cvitjs">Download CViTjs</a> and copy
     the code to your webserver. It might make the most sense to put the code directly into
-    this module's directory, in a subdirectory named <code>js/</code>. To download, execute 
+    this module's directory, in a subdirectory named <code>js/</code>. To download, execute
     the git command inside the <code>js/</code> subdirectory:<br>
     <code>git clone https://github.com/LegumeFederation/cvitjs.git</code>
   </li>
   <li>
-    CViTjs will have a config file in its root directory named cvit.conf. This file 
+    CViTjs will have a config file in its root directory named cvit.conf. This file
     provides information for whole genome visualization for each genome BLAST target.
     <b>Make sure the config file can be edited by your web server.</b>
   </li>
@@ -135,7 +137,7 @@ a genome image. The process is as follows:
   </li>
   <li>
     Enable CViTjs from the BLAST module administration page and provide the path to the
-    root directory for the CViTjs code relative to this module. For example, 
+    root directory for the CViTjs code relative to this module. For example,
     <code>js/cvitjs</code>.
   </li>
   <li>
@@ -148,20 +150,11 @@ defaultData = data/cajca/cajca.gff</pre>
     <ul>
       <li>the section name, "data.Cajanus cajan - genome", consists of "data." followed
           by the name of the BLAST target node,</li>
-      <li>the file "cajca.conf" is a cvit configuration file which describes how to draw the 
+      <li>the file "cajca.conf" is a cvit configuration file which describes how to draw the
           chromosomes and BLAST hits on the <i>Cajanus cajan</i> genome,</li>
-      <li>and the file "cajca.gff" is a GFF3 file that describes the <i>Cajanus cajan</i> 
+      <li>and the file "cajca.gff" is a GFF3 file that describes the <i>Cajanus cajan</i>
           chromosomes.</li>
     </ul>
-    The .conf file for each genome can be modified to suit your needs and tastes. See the
-    sample configuration file, <code>data/test1/test1.conf</code>, and the CViTjs
-    <a href="https://github.com/LegumeFederation/cvitjs#using-cvitjs">documentation</a>
-    
-    You will have to put the target-specific conf and gff files (e.g. cajca.conf and 
-    cjca.gff) on your web server, in the directory, <code>js/cvitjs/data</code>. You may 
-    choose to group files for each genome into subdirectories, for example, 
-    <code>js/cvitjs/data/cajca</code>.
-    <br><br>
     At the top of the configuration file there must be a [general] section that defines
     the default data set. For example:
     <pre>
@@ -169,15 +162,31 @@ defaultData = data/cajca/cajca.gff</pre>
 data_default = data.Cajanus cajan - genome</pre>
   </li>
   <li>
-    Edit the nodes for each genome target (nodes of type "BLAST Database") and enable whole 
-    genome visualization. Remember that the names listed in the CViTjs config file must 
+    Edit the nodes for each genome target (nodes of type "BLAST Database") and enable whole
+    genome visualization. Remember that the names listed in the CViTjs config file must
     match the BLAST node name. In the example above, the BLAST database node for the
     <i>Cajanus cajan</i> genome assembly is named "Cajanus cajan - genome"
   </li>
 </ol>
 
-It is important to make sure that cvit.conf points to the correct data directory and the
-correct .gff and .conf files for the genome in question. For more information about how to 
-create the .gff file, see the 
-<a href="https://github.com/LegumeFederation/cvitjs#how-to">documentation</a>.
-
+<h4>Notes</h4>
+<ul>
+<li>The .conf file for each genome can be modified to suit your needs and tastes. See the
+  sample configuration file, <code>data/test1/test1.conf</code>, and the CViTjs
+  <a href="https://github.com/LegumeFederation/cvitjs#using-cvitjs">documentation</a>.</li>
+<li>Each blast target CViTjs configuration file must define how to visualize blast hits or you will not see them.
+  <pre>[blast]
+feature = BLASTRESULT:match_part
+glyph   = position
+shape = rect
+color   = #FF00FF
+width = 5</pre></li>
+<li>You will have to put the target-specific conf and gff files (e.g. cajca.conf and
+  cjca.gff) on your web server, in the directory, <code>js/cvitjs/data</code>. You may
+  choose to group files for each genome into subdirectories, for example,
+  <code>js/cvitjs/data/cajca</code>.</li>
+<li>It is important to make sure that cvit.conf points to the correct data directory and the
+  correct .gff and .conf files for the genome in question. For more information about how to
+  create the .gff file, see the
+  <a href="https://github.com/LegumeFederation/cvitjs#how-to">documentation</a>.</li>
+</ul>

--- a/theme/blast_report.tpl.php
+++ b/theme/blast_report.tpl.php
@@ -72,13 +72,13 @@ $no_hits = TRUE;
         <a href="<?php print '../../' . $blast_job->files->result->gff; ?>">GFF3</a>
       </div>
       <br />
-      <div class="blast-query-info"><strong>Query Information</strong>: 
+      <div class="blast-query-info"><strong>Query Information</strong>:
         <?php print $blast_job->files->query;?></div>
-      <div class="blast-target-info"><strong>Search Target</strong>: 
+      <div class="blast-target-info"><strong>Search Target</strong>:
         <?php print $blast_job->blastdb->db_name;?></div>
-      <div class="blast-date-info"><strong>Submission Date</strong>: 
+      <div class="blast-date-info"><strong>Submission Date</strong>:
         <?php print format_date($blast_job->date_submitted, 'medium');?></div>
-      <div class="blast-cmd-info"><strong>BLAST Command executed</strong>: 
+      <div class="blast-cmd-info"><strong>BLAST Command executed</strong>:
         <?php print $blast_job->blast_cmd;?></div>
       <br />
       <div class="num-results">
@@ -87,38 +87,14 @@ $no_hits = TRUE;
     </div>
 
     <?php
-      if (variable_get('blast_ui_cvitjs_enabled', false)
-            && isset($blast_job->blastdb->cvitjs_enabled)
-            && $blast_job->blastdb->cvitjs_enabled == '1') {
-        $cvitjs_location = variable_get('blast_ui_cvitjs_location', '');
+      if ($show_cvit_diagram) {
     ?>
       <!-- CViTjs image of BLAST hits, if enabled -->
       <div class="cvitjs">
         <div id="title-div"></div>
         <div id="cvit-div"></div>
       </div>
-      <?php
-        drupal_add_js(array(
-          'blast_ui'=> array(
-            'dataset' => $blast_job->blastdb->db_name)
-          ),
-          'setting'
-        );
-        drupal_add_js(array(
-          'blast_ui'=> array(
-            'gff' => '../../' . $blast_job->files->result->gff)),'setting'
-        );    
-        $base = drupal_get_path('module','blast_ui') 
-                . DIRECTORY_SEPARATOR . $cvitjs_location
-                . DIRECTORY_SEPARATOR . 'js'
-                . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR;
-        drupal_add_css($base.'bootstrap/css/bootstrap.min.css',array('preprocess'=>FALSE));
-        drupal_add_css($base.'hopscotch/css/hopscotch.min.css',array('preprocess'=>FALSE));
-        drupal_add_css($base.'../../css/cvit.css',array('preprocess'=> FALSE));
-        drupal_add_js($base.'require/require.js',array('group'=>'JS_LIBRARY','type'=>'file'));
-        drupal_add_js($base.'require/blast_ui-config.js',array('group'=>'JS_THEME'));
-      ?>
-    <?php  
+    <?php
       }
     ?>
 
@@ -243,7 +219,7 @@ $no_hits = TRUE;
                               ';';
                 $Hsp_bit_score .=   $hsp_xml->{'Hsp_bit-score'} .';';
               }
-              
+
               // Finally record the range.
               // @todo figure out why we arbitrarily subtract 50,000 here...
               // @more removing the 50,000 and using track start/end appears to cause no change...

--- a/theme/blast_report.tpl.php
+++ b/theme/blast_report.tpl.php
@@ -62,7 +62,6 @@ $no_hits = TRUE;
 
 <div class="blast-report">
 
-  <div class="blast-job-info">
     <!-- Provide Information to the user about their blast job -->
     <div class="blast-job-info">
       <div class="blast-download-info"><strong>Download</strong>:
@@ -91,14 +90,14 @@ $no_hits = TRUE;
     ?>
       <!-- CViTjs image of BLAST hits, if enabled -->
       <div class="cvitjs">
-        <div id="title-div"></div>
+        <div id="title-div"><h2>Whole Genome Visualization of BLAST hits</h2></div>
         <div id="cvit-div"></div>
       </div>
+
     <?php
       }
     ?>
 
-  </div>
   <br />
 
   <div class="report-table">
@@ -110,6 +109,8 @@ $no_hits = TRUE;
 
     if ($xml) {
     ?>
+
+    <h2>Resulting BLAST hits</h2>
 
     <p>The following table summarizes the results of your BLAST.
     Click on a <em>triangle </em> on the left to see the alignment and a visualization of the hit,

--- a/theme/blast_ui.theme.inc
+++ b/theme/blast_ui.theme.inc
@@ -45,7 +45,7 @@ function blast_ui_preprocess_show_blast_report(&$vars) {
            . DIRECTORY_SEPARATOR . $cvitjs_location
            . DIRECTORY_SEPARATOR . 'js'
            . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR;
-    drupal_add_css($base.'bootstrap/css/bootstrap.min.css',array('preprocess'=>FALSE));
+    drupal_add_css($base.'bootstrap_embed/css/bootstrap.min.css',array('preprocess'=>FALSE));
     drupal_add_css($base.'hopscotch/css/hopscotch.min.css',array('preprocess'=>FALSE));
     drupal_add_css($base.'../../css/cvit.css',array('preprocess'=> FALSE));
     drupal_add_js($base.'require/require.js',array('group'=>'JS_LIBRARY','type'=>'file'));

--- a/theme/blast_ui.theme.inc
+++ b/theme/blast_ui.theme.inc
@@ -30,6 +30,37 @@ function blast_ui_preprocess_show_blast_report(&$vars) {
       $vars['blast_job']->blast_cmd .= ' -' . $key. ' ' . $value ;
   }
 
+  // CViTjs
+  $vars['show_cvit_diagram'] = FALSE;
+  if (variable_get('blast_ui_cvitjs_enabled', false)
+    && isset($vars['blast_job']->blastdb->cvitjs_enabled)
+    && $vars['blast_job']->blastdb->cvitjs_enabled == '1') {
+
+    // Set a clean var so we don't have to do this long check again ;-).
+    $vars['show_cvit_diagram'] = TRUE;
+
+    // Add the CSS/JS.
+    $cvitjs_location = variable_get('blast_ui_cvitjs_location', '');
+    $base = drupal_get_path('module','blast_ui')
+           . DIRECTORY_SEPARATOR . $cvitjs_location
+           . DIRECTORY_SEPARATOR . 'js'
+           . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR;
+    drupal_add_css($base.'bootstrap/css/bootstrap.min.css',array('preprocess'=>FALSE));
+    drupal_add_css($base.'hopscotch/css/hopscotch.min.css',array('preprocess'=>FALSE));
+    drupal_add_css($base.'../../css/cvit.css',array('preprocess'=> FALSE));
+    drupal_add_js($base.'require/require.js',array('group'=>'JS_LIBRARY','type'=>'file'));
+    drupal_add_js($base.'require/blast_ui-config.js',array('group'=>'JS_THEME'));
+
+    // Add the JS settings.
+    global $base_url;
+    drupal_add_js(array('blast_ui'=> array(
+            'dataset' => $vars['blast_job']->blastdb->db_name,
+            'gff' => $base_url . '/' . $vars['blast_job']->files->result->gff
+      )),
+      'setting'
+    );
+  }
+
   // Determine the URL of the blast form.
   $vars['blast_form_url'] = 'blast/nucleotide/nucleotide';
   switch($vars['blast_job']->program) {
@@ -129,7 +160,7 @@ function blast_ui_reveal_secret($secret) {
   // Check that the job_id exists if it is an integer.
   if (is_numeric($job_id)) {
 
-    $exists = db_query('SELECT job_id FROM {tripal_jobs} WHERE job_id=:id', 
+    $exists = db_query('SELECT job_id FROM {tripal_jobs} WHERE job_id=:id',
                        array(':id' => $job_id))->fetchField();
     if (!$exists) {
       tripal_report_error(
@@ -148,7 +179,7 @@ function blast_ui_reveal_secret($secret) {
 
     $job_id = base64_decode($secret);
     if (is_numeric($job_id)) {
-      $exists = db_query('SELECT job_id FROM {tripal_jobs} WHERE job_id=:id', 
+      $exists = db_query('SELECT job_id FROM {tripal_jobs} WHERE job_id=:id',
                          array(':id' => $job_id))->fetchField();
       if (!$exists) {
         tripal_report_error(

--- a/theme/css/blast_report.css
+++ b/theme/css/blast_report.css
@@ -77,9 +77,15 @@ table#blast_report div.alignment-subrow{
 }
 .blast-job-info {
   float: left;
+  margin-bottom: 25px;
 }
 .cvitjs {
   float: left;
+  margin-top: 10px;
+  margin-bottom: 25px;
+}
+.cvitjs #cvit-div{
+  padding: 5px 0 0 0;
 }
 .report-table {
   clear: both;

--- a/theme/node--blastdb.tpl.php
+++ b/theme/node--blastdb.tpl.php
@@ -108,6 +108,28 @@
       <tr><th>Whole Genome Viewer</th><td><?php print ($node->cvitjs_enabled) ? 'Enabled' : 'Disabled'; ?></td></tr>
     </table>
 
+
+    <?php
+      if ($node->cvitjs_enabled) {
+
+        print '<h3>Whole Genome Viewer</h3>';
+
+        $conf_section = blast_ui_get_cvit_conf_text('data.'.$node->db_name);
+
+        if (!$conf_section) {
+
+          print '<div class="messages warning">There is no section for this genome target defined in the CViTjs
+            configuration file. <strong>No genome visualization will be shown until you define a
+            configuration section, "[data.'.$form_state['values']['db_name'].']", at '
+            .l('Admin > Tripal > Extensions > Tripal BLAST > BLAST UI', 'admin/tripal/extension/tripal_blast')
+            .'</strong>.</div>';
+        }
+        else {
+          print '<h4>Configuration</h4>'
+            . '<pre>'.$conf_section.'</pre>';
+        }
+    }
+    ?>
     <?php
       // Add in any remaining content
       print render($content);

--- a/theme/node--blastdb.tpl.php
+++ b/theme/node--blastdb.tpl.php
@@ -105,6 +105,7 @@
       <tr><th>RegEx</th><td><?php print $node->linkout->regex; ?></td></tr>
       <tr><th>Link-out Type</th><td><?php print $node->linkout->type; ?></td></tr>
 <?php } ?>
+      <tr><th>Whole Genome Viewer</th><td><?php print ($node->cvitjs_enabled) ? 'Enabled' : 'Disabled'; ?></td></tr>
     </table>
 
     <?php


### PR DESCRIPTION
This PR contains my improvements to the CViTjs Whole Genome View of BLAST hits functionality. Specifically, it contains the following (see commits):
 - Move drupal_add_css/js() into preprocessor hook to ensure it is loaded at the correct point
 - Improvements to the BLAST Administration form:
        - Expand cvit fieldset when it's enabled
        - Disable cvit path form element when cvit is disabled
        - Added helpful message to admins pointing to the CViTjs data directory.
 - Improvements to blast database node add/edit/view
        - Added warning to blastdb node pages when cvitjs is enabled but there is no config stanza
        - Added config info to node page
 - Utilized CViTjs embedding-specific bootstrap to minimize theme collisions
 - Small tweaks to themeing of the BLAST results page to make the cvitjs diagram more seamless.

NOTE: This PR doesn't move CViTjs into the libraries folder since this point needs further discussion.